### PR TITLE
Change instruction highlight color

### DIFF
--- a/syntax/rgbds.vim
+++ b/syntax/rgbds.vim
@@ -69,7 +69,7 @@ let b:current_syntax = "rgb"
 hi link rgbSection     Special
 hi link rgbLabel       Identifier
 hi link rgbComment     Comment
-hi link rgbInstruction Ignore
+hi link rgbInstruction Statement
 hi link rgbInclude     Include
 hi link rgbPreCondit   PreCondit
 hi link rgbMacro       Macro


### PR DESCRIPTION
I have changed the instruction highlight from 'Ignore' to 'Statement', because it looks way more natural on dark-background terminals. Dark 'Ignore' highlight is barely unreadable on terminals like gnome-terminal and xterm imo.